### PR TITLE
Fix typo for icon path (.\icons -> ./icons)

### DIFF
--- a/ruler/overlay_window.py
+++ b/ruler/overlay_window.py
@@ -342,7 +342,7 @@ class OverlayWindow:
         try:
             icon_names = ["start", "wait", "deco", "timer"]
             for name in icon_names:
-                path = resource_path(os.path.join(".\icons", f"{name}.png"))
+                path = resource_path(os.path.join("./icons", f"{name}.png"))
                 img = Image.open(path).convert("RGBA")
                 self.icons[name] = ImageTk.PhotoImage(image=img)
             logger.debug("图标资源加载完成。")


### PR DESCRIPTION
This is to fix one of the issues in my opened #25 

For this error message:
```2025-08-29 02:34:07 - overlay_window                      - CRITICAL - 错误: 缺少图标文件 /home/zhurai/.arknights/source/ArknightsCostBarRuler/.\icons/start.png。请确保资源文件完整。```

Without this change/without creating symbolic links, this has caused the script to fail
I've tested this locally, and it resolves the issue.
